### PR TITLE
Update build.properties to bump sbt version to 0.13.18

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.13
+sbt.version = 0.13.18


### PR DESCRIPTION
A more recent sbt version is necessary to force sbt to use https in all repositories because some of the necessary HTTP repositories are not available anymore.